### PR TITLE
Yield the alias and fallback to name when checking the condition proc

### DIFF
--- a/lib/rabl/builder.rb
+++ b/lib/rabl/builder.rb
@@ -216,9 +216,11 @@ module Rabl
       # resolve_condition(:unless => lambda { |m| false }) => true
       # resolve_condition(:unless => lambda { |m| false }, :if => proc { true}) => true
       def resolve_condition(options)
+        name = (options[:as] || options[:name]).to_s
+
         result = true
-        result &&= call_condition_proc(options[:if], @_object, options[:name]) if options.key?(:if)
-        result &&= !call_condition_proc(options[:unless], @_object, options[:name]) if options.key?(:unless)
+        result &&= call_condition_proc(options[:if], @_object, name) if options.key?(:if)
+        result &&= !call_condition_proc(options[:unless], @_object, name) if options.key?(:unless)
         result
       end
 


### PR DESCRIPTION
If `options[:as]` exists, prefer it over the name.

This fixes an issue where attributes are mapped, for example:

```Ruby
attribute :this => :that
```

In the case above `options[:as]` is going to be `:that`.

We need to filter based on the aliased name.