### PR TITLE
Builder#{node,child}: include 'name' as an argument for #resolve_condition

### DIFF
--- a/lib/rabl/builder.rb
+++ b/lib/rabl/builder.rb
@@ -147,7 +147,7 @@ module Rabl
       # node(:foo) { "bar" }
       # node(:foo, :if => lambda { |m| m.foo.present? }) { "bar" }
       def node(name, options = {}, &block)
-        return unless resolve_condition(options)
+        return unless resolve_condition(options.merge({ :name => name }))
 
         result = block.call(@_object)
         if name.present?

--- a/lib/rabl/builder.rb
+++ b/lib/rabl/builder.rb
@@ -163,9 +163,10 @@ module Rabl
       # child(@user => :person) { ... }
       # child(@users => :people) { ... }
       def child(data, options = {}, &block)
-        return unless data.present? && resolve_condition(options)
-
         name   = is_name_value?(options[:root]) ? options[:root] : data_name(data)
+
+        return unless data.present? && resolve_condition(options.merge({ :name => name}))
+
         object = data_object(data)
 
         engine_options = @options.slice(:child_root)


### PR DESCRIPTION
After this change:
https://github.com/catawiki/rabl/commit/078d14fe881b79c99ded7a6def56a288e39769d9
we've got an option to pass a name of an attribute to the `resolve_condition` method and further.

The problem now is that in the cases when a `node` is used the same lambda or proc returns different results. It happens because `resolve_condition` method does not receive the `name` parameter. 
Unless you state it explicitly: `node(:foo, :name => 'foo')`
As a result, the same lambda applied for an attribute or node will behave differently.

After the change, both `#attribute` and `#node` will react in the same way when the name is present.
Nothing changes for the nodes without a name (anonymous node).