### PR TITLE
Lock rack-test gem to version ~> 0.7.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'builder'
 
   # FIXTURES
-  gem 'rack-test', :require => 'rack/test'
+  gem 'rack-test', '~> 0.7.0', :require => 'rack/test'
   gem 'activerecord', :require => 'active_record'
   gem 'sqlite3'
   gem 'sinatra', '~> 1.4'


### PR DESCRIPTION
Versions >= 0.8 require Ruby 2.2:
https://rubygems.org/gems/rack-test/versions/0.8.0

Specs were failing for Ruby 1.8 and 1.9 (see https://github.com/catawiki/rabl/pull/3#issuecomment-358480356):

<img width="598" alt="failing_specs" src="https://user-images.githubusercontent.com/11336/35072222-f9a68354-fbe3-11e7-8cec-3aa571a7e765.png">